### PR TITLE
making minheap compatible with Allegro mlisp

### DIFF
--- a/binary-heap.lisp
+++ b/binary-heap.lisp
@@ -19,7 +19,7 @@
 ;;;; TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ;;;; SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-(defpackage :binary-heap (:use :CL)
+(defpackage :binary-heap (:use :cl)
   (:export
    #:binary-heap
    #:clear-heap

--- a/fib-heap.lisp
+++ b/fib-heap.lisp
@@ -19,7 +19,7 @@
 ;;;; TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ;;;; SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-(defpackage :fib-heap (:use :CL)
+(defpackage :fib-heap (:use :cl)
   (:export
    #:fib-heap
    #:clear-heap

--- a/pairing-heap-elmasri.lisp
+++ b/pairing-heap-elmasri.lisp
@@ -19,7 +19,7 @@
 ;;;; TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ;;;; SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-(defpackage :pairing-elmasri (:use :CL)
+(defpackage :pairing-elmasri (:use :cl)
   (:export
    #:pairing-elmasri
    #:clear-heap

--- a/pairing-heap-listbased.lisp
+++ b/pairing-heap-listbased.lisp
@@ -19,7 +19,7 @@
 ;;;; TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ;;;; SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-(defpackage :pairing-heap-list (:use :CL)
+(defpackage :pairing-heap-list (:use :cl)
   (:export
    #:pairing-heap
    #:clear-heap

--- a/pairing-heap.lisp
+++ b/pairing-heap.lisp
@@ -19,7 +19,7 @@
 ;;;; TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ;;;; SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-(defpackage :pairing-heap (:use :CL)
+(defpackage :pairing-heap (:use :cl)
   (:export
    #:pairing-heap
    #:clear-heap

--- a/rank-pairing-heap-clist.lisp
+++ b/rank-pairing-heap-clist.lisp
@@ -19,7 +19,7 @@
 ;;;; TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ;;;; SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-(defpackage :rank-pairing-heap-clist (:use :CL)
+(defpackage :rank-pairing-heap-clist (:use :cl)
   (:export
    #:rank-pairing-heap-clist
    #:clear-heap

--- a/rank-pairing-heap.lisp
+++ b/rank-pairing-heap.lisp
@@ -19,7 +19,7 @@
 ;;;; TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ;;;; SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-(defpackage :rank-pairing-heap (:use :CL)
+(defpackage :rank-pairing-heap (:use :cl)
   (:export
    #:rank-pairing-heap
    #:clear-heap

--- a/splay-heap.lisp
+++ b/splay-heap.lisp
@@ -19,7 +19,7 @@
 ;;;; TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ;;;; SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-(defpackage :splay-heap (:use :CL)
+(defpackage :splay-heap (:use :cl)
   (:export
    #:pairing-heap
    #:clear-heap

--- a/violation-heap.lisp
+++ b/violation-heap.lisp
@@ -19,7 +19,7 @@
 ;;;; TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ;;;; SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-(defpackage :violation-heap (:use :CL)
+(defpackage :violation-heap (:use :cl)
   (:export
    #:violation-heap
    #:clear-heap


### PR DESCRIPTION
This makes `minheap` load under Allegro Common Lisp "modern" (`mlisp`).
